### PR TITLE
Add feature flags for RS3 and HDOSAndRuneLite as well as .desktop and icon file support

### DIFF
--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -20,6 +20,7 @@
   expat,
   libxkbcommon,
   gtk3,
+  jdk17,
   pango,
   cairo,
   alsa-lib,
@@ -31,8 +32,6 @@
   makeDesktopItem,
   copyDesktopItems,
   enableRS3 ? false,
-  enableHDOSAndRuneLite ? false,
-  jdk17 ? null,
 }:
 let
   cef = libcef.overrideAttrs (oldAttrs: {
@@ -114,8 +113,6 @@ let
         libarchive
         libz
         cef
-      ]
-      ++ lib.optionals enableHDOSAndRuneLite [
         jdk17
       ];
 
@@ -143,7 +140,7 @@ let
 
     postFixup = ''
       makeWrapper "$out/opt/bolt-launcher/bolt" "$out/bin/${finalAttrs.pname}-${finalAttrs.version}" \
-      ${lib.optionalString enableHDOSAndRuneLite "--set JAVA_HOME ${jdk17}"}
+      --set JAVA_HOME ${jdk17}
       mkdir -p $out/lib
       cp $out/usr/local/lib/libbolt-plugin.so $out/lib
       mkdir -p $out/share/icons/hicolor/256x256/apps
@@ -208,8 +205,7 @@ buildFHSEnv {
     homepage = "https://github.com/Adamcake/Bolt";
     description = "An alternative launcher for RuneScape.";
     longDescription = ''
-      Bolt Launcher supports RS3 and HDOS/RuneLite through optional feature flags.
-      Use enableRS3 to include dependencies for RS3, and enableHDOSAndRuneLite for HDOS/RuneLite support.
+      Bolt Launcher supports HDOS/RuneLite by default with an optional feature flag for RS3 (enableRS3).
     '';
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ nezia ];

--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -105,16 +105,15 @@ let
       copyDesktopItems
     ];
 
-    buildInputs =
-      [
-        mesa
-        xorg.libX11
-        xorg.libxcb
-        libarchive
-        libz
-        cef
-        jdk17
-      ];
+    buildInputs = [
+      mesa
+      xorg.libX11
+      xorg.libxcb
+      libarchive
+      libz
+      cef
+      jdk17
+    ];
 
     cmakeFlags = [
       "-D CMAKE_BUILD_TYPE=Release"

--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -7,7 +7,6 @@
   ninja,
   libarchive,
   libz,
-  jdk17,
   libcef,
   luajit,
   xorg,
@@ -29,6 +28,9 @@
   cups,
   systemd,
   buildFHSEnv,
+  enableRS3 ? false,
+  enableHDOSAndRuneLite ? false,
+  jdk17 ? null,
 }:
 let
   cef = libcef.overrideAttrs (oldAttrs: {
@@ -108,6 +110,8 @@ let
       libarchive
       libz
       cef
+    ]
+    ++ lib.optionals enableHDOSAndRuneLite [
       jdk17
     ];
 
@@ -135,8 +139,7 @@ let
 
     postFixup = ''
       makeWrapper "$out/opt/bolt-launcher/bolt" "$out/bin/${finalAttrs.pname}-${finalAttrs.version}" \
-      --set JAVA_HOME "${jdk17}"
-      ls -al $out/bin
+      ${lib.optionalString enableHDOSAndRuneLite "--set JAVA_HOME ${jdk17}"}
       mkdir -p $out/lib
       cp $out/usr/local/lib/libbolt-plugin.so $out/lib
     '';
@@ -156,19 +159,25 @@ buildFHSEnv {
       pango
       cairo
       gdk-pixbuf
-      gtk2-x11
       libz
       libcap
       libsecret
-      openssl_1_1
       SDL2
       libGL
+    ])
+    ++ lib.optionals enableRS3 (with pkgs; [
+      gtk2-x11
+      openssl_1_1
     ]);
 
   runScript = "${bolt.name}";
   meta = {
     homepage = "https://github.com/Adamcake/Bolt";
-    description = "An alternative launcher for RuneScape";
+    description = "An alternative launcher for RuneScape.";
+    longDescription = ''
+      Bolt Launcher supports RS3 and HDOS/RuneLite through optional feature flags.
+      Use enableRS3 to include dependencies for RS3, and enableHDOSAndRuneLite for HDOS/RuneLite support.
+    '';
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ nezia ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -106,17 +106,18 @@ let
       copyDesktopItems
     ];
 
-    buildInputs = [
-      mesa
-      xorg.libX11
-      xorg.libxcb
-      libarchive
-      libz
-      cef
-    ]
-    ++ lib.optionals enableHDOSAndRuneLite [
-      jdk17
-    ];
+    buildInputs =
+      [
+        mesa
+        xorg.libX11
+        xorg.libxcb
+        libarchive
+        libz
+        cef
+      ]
+      ++ lib.optionals enableHDOSAndRuneLite [
+        jdk17
+      ];
 
     cmakeFlags = [
       "-D CMAKE_BUILD_TYPE=Release"
@@ -184,10 +185,13 @@ buildFHSEnv {
       SDL2
       libGL
     ])
-    ++ lib.optionals enableRS3 (with pkgs; [
-      gtk2-x11
-      openssl_1_1
-    ]);
+    ++ lib.optionals enableRS3 (
+      with pkgs;
+      [
+        gtk2-x11
+        openssl_1_1
+      ]
+    );
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications

--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -28,6 +28,8 @@
   cups,
   systemd,
   buildFHSEnv,
+  makeDesktopItem,
+  copyDesktopItems,
   enableRS3 ? false,
   enableHDOSAndRuneLite ? false,
   jdk17 ? null,
@@ -101,6 +103,7 @@ let
       ninja
       luajit
       makeWrapper
+      copyDesktopItems
     ];
 
     buildInputs = [
@@ -142,7 +145,23 @@ let
       ${lib.optionalString enableHDOSAndRuneLite "--set JAVA_HOME ${jdk17}"}
       mkdir -p $out/lib
       cp $out/usr/local/lib/libbolt-plugin.so $out/lib
+      mkdir -p $out/share/icons/hicolor/256x256/apps
+      cp ../icon/256.png $out/share/icons/hicolor/256x256/apps/${finalAttrs.pname}.png
     '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        type = "Application";
+        terminal = false;
+        name = "Bolt";
+        desktopName = "Bolt Launcher";
+        genericName = finalAttrs.pname;
+        comment = "An alternative launcher for RuneScape";
+        exec = "${finalAttrs.pname}-${finalAttrs.version}";
+        icon = finalAttrs.pname;
+        categories = [ "Game" ];
+      })
+    ];
   });
 in
 buildFHSEnv {
@@ -170,7 +189,17 @@ buildFHSEnv {
       openssl_1_1
     ]);
 
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+
+    ln -s ${bolt}/share/applications/*.desktop $out/share/applications/
+
+    ln -s ${bolt}/share/icons/hicolor/256x256/apps/*.png $out/share/icons/hicolor/256x256/apps/
+  '';
+
   runScript = "${bolt.name}";
+
   meta = {
     homepage = "https://github.com/Adamcake/Bolt";
     description = "An alternative launcher for RuneScape.";


### PR DESCRIPTION
This PR adopts @Adamcake 's approach to optional dependencies used in the AUR package. This avoids having a compromised library as a requirement.

This PR also adds support for creating and linking/copying a .desktop file and corresponding icon. This has the effect of causing the package to show up in app launchers when added to a system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability of the bolt-launcher package with optional dependencies.
	- Introduced new feature flags for RS3 and HDOS/RuneLite support.
	- Added a desktop entry for improved application integration.

- **Improvements**
	- Updated package configuration to conditionally include JDK 17 based on user preferences.
	- Enhanced the package's long description for better clarity on optional features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->